### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use this plugin, you must already have a Drupal project using BLT 12 or highe
 
 In your project, require the plugin with Composer:
 
-`composer require –dev acquia/blt-drupal-check`
+`composer require --dev acquia/blt-drupal-check`
 
 # License
 


### PR DESCRIPTION
The double-dash was transformed in this readme.