### PR TITLE
Added tests:deprecated command

### DIFF
--- a/src/Blt/Plugin/Commands/DrupalCheckCommand.php
+++ b/src/Blt/Plugin/Commands/DrupalCheckCommand.php
@@ -13,7 +13,7 @@ class DrupalCheckCommand extends BltTasks {
   /**
    * Executes the deprecation-validate command.
    *
-   * @command tests:deprecated:modules
+   * @command tests:deprecatedmodules
    */
   public function validateDeprecatedModules() {
     $this->runDrupalCheck('modules');
@@ -22,7 +22,7 @@ class DrupalCheckCommand extends BltTasks {
   /**
    * Executes the deprecation-validate command.
    *
-   * @command tests:deprecated:themes
+   * @command tests:deprecatedthemes
    */
   public function validateDeprecatedThemes() {
     $this->runDrupalCheck('themes');

--- a/src/Blt/Plugin/Commands/DrupalCheckCommand.php
+++ b/src/Blt/Plugin/Commands/DrupalCheckCommand.php
@@ -13,7 +13,17 @@ class DrupalCheckCommand extends BltTasks {
   /**
    * Executes the deprecation-validate command.
    *
-   * @command tests:deprecatedmodules
+   * @command tests:deprecated
+   */
+  public function validateDeprecated() {
+    $this->validateDeprecatedModules();
+    $this->validateDeprecatedThemes();
+  }
+  
+  /**
+   * Executes the deprecation-validate command.
+   *
+   * @command tests:deprecated:modules
    */
   public function validateDeprecatedModules() {
     $this->runDrupalCheck('modules');
@@ -22,7 +32,7 @@ class DrupalCheckCommand extends BltTasks {
   /**
    * Executes the deprecation-validate command.
    *
-   * @command tests:deprecatedthemes
+   * @command tests:deprecated:themes
    */
   public function validateDeprecatedThemes() {
     $this->runDrupalCheck('themes');


### PR DESCRIPTION
Addresses issue with blt tests command returning an error of tests:deprecated is not defined. 

https://github.com/acquia/blt-drupal-check/issues/3